### PR TITLE
posix/outpost/rtos/thread.cpp: replace pthread_yield() with sched_yield()

### DIFF
--- a/modules/rtos/arch/posix/outpost/rtos/thread.cpp
+++ b/modules/rtos/arch/posix/outpost/rtos/thread.cpp
@@ -124,7 +124,7 @@ void
 Thread::yield()
 {
     // On Linux, this call always succeeds
-    pthread_yield();
+    sched_yield();
 }
 
 void


### PR DESCRIPTION
Hello,

We are setting up Outpost to work on macOS and of all changes that are needed, this change is the easiest to be the first one to suggest here.

Manual: http://man7.org/linux/man-pages/man3/pthread_yield.3.html suggests

```
This call is nonstandard, but present on several other systems.  Use
the standardized sched_yield(2) instead.
```

The pthread_yield() call is not available on macOS, but sched_yield() is
available so it seems reasonable and safe to use the sched_yield() version.

See also:

```
NOTES

On Linux, this function is implemented as a call to sched_yield(2).
```

Thanks.