### PR TITLE
Update INSTALL.md fix a typo in the lua  version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ Requires `lcov` >= 1.10.
 ```
 sudo apt-get install libreadline-dev
 
-wget http://www.lua.org/ftp/lua-5.2.3.tar.gz
+wget http://www.lua.org/ftp/lua-5.3.4.tar.gz
 tar zxf lua-5.3.4.tar.gz
 cd lua-5.3.4
 make linux


### PR DESCRIPTION
The prepending header and the following commands are refering to Lua version 5.3.4