### PR TITLE
Fix heap buffer overread

### DIFF
--- a/modules/utils/src/outpost/utils/coding/cobs_impl.h
+++ b/modules/utils/src/outpost/utils/coding/cobs_impl.h
@@ -115,7 +115,7 @@ CobsEncodingGeneratorBase<blockLength>::findNextBlock()
     // - The end of the input array is reached.
     if (mData != nullptr)
     {
-        while ((mData[position] != 0) && (blockSize < blockLength) && (position < mLength))
+        while ((position < mLength) && (mData[position] != 0) && (blockSize < blockLength))
         {
             position++;
             blockSize++;


### PR DESCRIPTION
moving the boundaries check in front of the while condition fixes the off by one overread, because of [short-circuit-evaluation](http://c-faq.com/expr/shortcircuit.html)